### PR TITLE
Add opts + action_type to Bulk.encode(!)/4

### DIFF
--- a/test/elasticsearch/indexing/bulk_test.exs
+++ b/test/elasticsearch/indexing/bulk_test.exs
@@ -81,7 +81,7 @@ defmodule Elasticsearch.Index.BulkTest do
     end
   end
 
-  describe ".encode!/3" do
+  describe ".encode!/4" do
     test "respects _routing meta-field" do
       assert Bulk.encode!(Cluster, %Comment{id: "my-id", post_id: "123"}, "my-index") =~
                "\"_routing\":\"123\""

--- a/test/elasticsearch/indexing/bulk_test.exs
+++ b/test/elasticsearch/indexing/bulk_test.exs
@@ -86,5 +86,15 @@ defmodule Elasticsearch.Index.BulkTest do
       assert Bulk.encode!(Cluster, %Comment{id: "my-id", post_id: "123"}, "my-index") =~
                "\"_routing\":\"123\""
     end
+
+    test "accepts an `action_type` option" do
+      assert Bulk.encode!(Cluster, %Comment{id: "my-id", post_id: "123"}, "my-index",
+               action_type: "create"
+             ) =~ "{\"create\":{\"_routing\":\"123\""
+
+      assert Bulk.encode!(Cluster, %Comment{id: "my-id", post_id: "123"}, "my-index",
+               action_type: "index"
+             ) =~ "{\"index\":{\"_routing\":\"123\""
+    end
   end
 end


### PR DESCRIPTION
This PR includes a change to `Bulk.encode/3` that adds a new `opts` param so that users can pass an action type besides "create", like "index", that can be used for bulk updating documents.

I know that there's a 2.0 rewrite happening that should expose more of the Bulk API, but this is something that we needed right now as we get rate limited by our Elasticsearch provider because they don't support concurrent index updates.

More context: https://github.com/danielberkompas/elasticsearch-elixir/issues/64

Example usage:

```elixir
cluster = Dk.Elasticsearch.Cluster
config = Elasticsearch.Cluster.Config.get(cluster)
action_type = "index"

items =
  structs
  |> Dk.Repo.preload(document_preloads())
  |> Enum.map(
    &Elasticsearch.Index.Bulk.encode!(cluster, &1, index_name(), action_type: action_type)
  )

Elasticsearch.put( config, "/#{index_name()}/_doc/_bulk", Enum.join(items))
|> case do
  {:error, exception} ->
    Dk.Elasticsearch.send_elasticsearch_exception_notification(
      exception,
      %{action_type: action_type, caller: "Dk.Elasticsearch.Products.put_documents/1"}
    )

    {:error, exception}

  {:ok, response} ->
    {:ok, response}
end
```

cc @silviurosu