### PR TITLE
Fix minor errors found by Dialyzer

### DIFF
--- a/lib/elasticsearch/api/aws.ex
+++ b/lib/elasticsearch/api/aws.ex
@@ -118,7 +118,7 @@ if Code.ensure_loaded?(Sigaws) do
     def build_signed_request(url, options, default_headers) when is_nil(default_headers) do
       {:ok, signed_data, _} = Sigaws.sign_req(url, options)
 
-      Map.merge(%{"Content-Type": "application/json"}, signed_data)
+      Map.merge(%{"Content-Type" => "application/json"}, signed_data)
     end
 
     def build_signed_request(url, options, default_headers) do

--- a/lib/elasticsearch/indexing/index.ex
+++ b/lib/elasticsearch/indexing/index.ex
@@ -34,8 +34,8 @@ defmodule Elasticsearch.Index do
 
     with :ok <- create_from_file(config, name, settings_file),
          :ok <- Bulk.upload(config, name, index_config),
-         :ok <- __MODULE__.alias(config, name, alias),
-         :ok <- clean_starting_with(config, alias, 2),
+         :ok <- __MODULE__.alias(config, name, to_string(alias)),
+         :ok <- clean_starting_with(config, to_string(alias), 2),
          :ok <- refresh(config, name) do
       :ok
     end


### PR DESCRIPTION
Dialyzer found three call sites where atoms are used, but strings are expected:

1. the header map for `HTTPoison.request/5` - its signature requires strings as keys
2. two functions in `Elasticsearch.Index` that expect strings for index name, but received atoms

Fixing this allows dependent projects to use Dialyzer without warnings.