### PR TITLE
Bump Elasticsearch to 6.8.1 in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -31,7 +31,7 @@ if [ ! $CI ]; then
 
   rm -rf vendor/;
   mkdir vendor/;
-  mix elasticsearch.install vendor --version 5.1.1 || { echo "Elasticsearch could not be installed!"; exit 1; }
+  mix elasticsearch.install vendor --version 6.8.1 || { echo "Elasticsearch could not be installed!"; exit 1; }
 fi
 
 echo "----------------------------------------------------------"


### PR DESCRIPTION
Current version of package seems to work with Elasticsearch 6.x.x+ only, so development setup script has to be updated to match the desired version.
