### PR TITLE
Make vex dependency less strict

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Elasticsearch.Mixfile do
     [
       {:poison, ">= 0.0.0", optional: true},
       {:httpoison, ">= 0.0.0"},
-      {:vex, "~> 0.6.0"},
+      {:vex, ">= 0.6.0 and < 0.9.0"},
       {:sigaws, "~> 0.7", optional: true},
       {:postgrex, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "sigaws": {:hex, :sigaws, "0.7.2", "2b0bcd3979f2ae19337d0a6e52b4b1f37ac3d778201019240e641471a2d36685", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "vex": {:hex, :vex, "0.6.0", "4e79b396b2ec18cd909eed0450b19108d9631842598d46552dc05031100b7a56", [:mix], [], "hexpm"},
+  "vex": {:hex, :vex, "0.8.0", "0a04e3aebe5ec443525c88f3833b4481d97de272f891243b62b18efbda85b121", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
I'd like to use this package in projects that depend on the latest versions of `vex` without the need of `override: true`.