### PR TITLE
Support runtime configuration via {:system, _} tuple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache:
   directories:
     - $HOME/.mix
 elixir:
-  - 1.7.2
+  - 1.9.1
 otp_release:
-  - 20.1
+  - 22.0
 env:
   - ELASTICSEARCH_VERSION=6.2.4
   - ELASTICSEARCH_VERSION=6.5.2

--- a/lib/elasticsearch/cluster/config.ex
+++ b/lib/elasticsearch/cluster/config.ex
@@ -109,5 +109,11 @@ defmodule Elasticsearch.Cluster.Config do
     end
   end
 
+  defp get_config_value(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} -> {key, get_config_value(value)} end)
+    |> Map.new()
+  end
+
   defp get_config_value(value), do: value
 end

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -49,7 +49,7 @@ defmodule Elasticsearch.Index.Bulk do
       \"\"\"
 
       iex> Bulk.encode!(Cluster, 123, "my-index")
-      ** (Protocol.UndefinedError) protocol Elasticsearch.Document not implemented for 123. This protocol is implemented for: Comment, Post
+      ** (Protocol.UndefinedError) protocol Elasticsearch.Document not implemented for 123 of type Integer. This protocol is implemented for the following type(s): Post, Comment
   """
   def encode!(cluster, struct, index) do
     config = Cluster.Config.get(cluster)

--- a/test/elasticsearch/cluster/config_test.exs
+++ b/test/elasticsearch/cluster/config_test.exs
@@ -1,11 +1,77 @@
 defmodule Elasticsearch.Cluster.ConfigTest do
   use ExUnit.Case
 
+  alias Elasticsearch.Cluster
   alias Elasticsearch.Cluster.Config
 
-  describe ".build/2" do
-    test "handles nil as first argument" do
-      assert %{key: "value"} = Config.build(nil, %{key: "value"})
+  describe ".build/3" do
+    test "uses simple values" do
+      assert %{username: "username", password: "password", port: 1234} =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: "username",
+                 password: "password",
+                 port: 1234
+               })
     end
+
+    test "fetches settings from environment variables" do
+      set_envs(%{
+        "ELASTICSEARCH_USERNAME" => "username",
+        "ELASTICSEARCH_PASSWORD" => "password",
+        "ELASTICSEARCH_PORT" => "1234"
+      })
+
+      assert %{username: "username", password: "password", port: 1234} =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: {:system, "ELASTICSEARCH_USERNAME"},
+                 password: {:system, "ELASTICSEARCH_PASSWORD"},
+                 port: {:system, :integer, "ELASTICSEARCH_PORT"}
+               })
+    end
+
+    test "prefers environment variable over the default value" do
+      set_envs(%{
+        "ELASTICSEARCH_USERNAME" => "username",
+        "ELASTICSEARCH_PASSWORD" => "password",
+        "ELASTICSEARCH_PORT" => "1234"
+      })
+
+      assert %{username: "username", password: "password", port: 1234} =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: {:system, "ELASTICSEARCH_USERNAME", "other_username"},
+                 password: {:system, "ELASTICSEARCH_PASSWORD", "other_password"},
+                 port: {:system, :integer, "ELASTICSEARCH_PORT", 4321}
+               })
+    end
+
+    test "falls back to default value if environment variable is not set" do
+      assert %{username: "username", password: "password", port: 1234} =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: {:system, "ELASTICSEARCH_USERNAME", "username"},
+                 password: {:system, "ELASTICSEARCH_PASSWORD", "password"},
+                 port: {:system, :integer, "ELASTICSEARCH_PORT", 1234}
+               })
+    end
+
+    test "falls back to nil if neither environment variable nor default value are set" do
+      assert %{username: nil, password: nil, port: nil} =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: {:system, "ELASTICSEARCH_USERNAME"},
+                 password: {:system, "ELASTICSEARCH_PASSWORD"},
+                 port: {:system, :integer, "ELASTICSEARCH_PORT"}
+               })
+    end
+  end
+
+  defp set_envs(envs) do
+    for {key, value} <- envs do
+      System.put_env(key, value)
+    end
+
+    on_exit(fn ->
+      for {key, _value} <- envs do
+        System.delete_env(key)
+      end
+    end)
   end
 end

--- a/test/elasticsearch/cluster/config_test.exs
+++ b/test/elasticsearch/cluster/config_test.exs
@@ -61,6 +61,33 @@ defmodule Elasticsearch.Cluster.ConfigTest do
                  port: {:system, :integer, "ELASTICSEARCH_PORT"}
                })
     end
+
+    test "allows to use {:system, _} tuple in nested maps" do
+      set_envs(%{
+        "ELASTICSEARCH_USERNAME" => "username",
+        "ELASTICSEARCH_PASSWORD" => "password",
+        "POSTS_BULK_PAGE_SIZE" => "5000"
+      })
+
+      assert %{
+               username: "username",
+               password: "password",
+               indexes: %{
+                 posts: %{
+                   bulk_page_size: 5000
+                 }
+               }
+             } =
+               Config.build(:elasticsearch, Cluster, %{
+                 username: {:system, "ELASTICSEARCH_USERNAME"},
+                 password: {:system, "ELASTICSEARCH_PASSWORD"},
+                 indexes: %{
+                   posts: %{
+                     bulk_page_size: {:system, :integer, "POSTS_BULK_PAGE_SIZE"}
+                   }
+                 }
+               })
+    end
   end
 
   defp set_envs(envs) do


### PR DESCRIPTION
Currently it is not obvious that one can override `MyApp.Cluster.init/1` for runtime configuration unless you read the source code. So, I did 2 changes there:

1. Added support for more idiomatic `{:system, _}` tuple
2. Added description of both configuration methods to readme
