### PR TITLE
Fixes for installing versions > 7.0.0 and configuring port for elasticsearch test

### DIFF
--- a/lib/elasticsearch/executable.ex
+++ b/lib/elasticsearch/executable.ex
@@ -29,7 +29,7 @@ defmodule Elasticsearch.Executable do
     case System.cmd("lsof", ["-i", ":#{port_number}"]) do
       {"", _} ->
         wrap = Application.app_dir(:elasticsearch) <> "/priv/bin/wrap"
-        port = Port.open({:spawn, "#{wrap} #{executable} --port #{port_number}"}, [])
+        port = Port.open({:spawn, "#{wrap} #{executable} -E http.port=#{port_number}"}, [])
         {:os_pid, os_pid} = Port.info(port, :os_pid)
         IO.puts("[info] Running #{name} with PID #{os_pid} on port #{port_number}")
         {:ok, port}

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -49,7 +49,7 @@ defmodule Elasticsearch.Index.Bulk do
       \"\"\"
 
       iex> Bulk.encode!(Cluster, 123, "my-index")
-      ** (Protocol.UndefinedError) protocol Elasticsearch.Document not implemented for 123. This protocol is implemented for: Comment, Post
+      ** (Protocol.UndefinedError) protocol Elasticsearch.Document not implemented for 123 of type Integer. This protocol is implemented for the following type(s): Post, Comment
   """
   def encode!(cluster, struct, index) do
     config = Cluster.Config.get(cluster)

--- a/lib/mix/elasticsearch.install.ex
+++ b/lib/mix/elasticsearch.install.ex
@@ -47,8 +47,8 @@ defmodule Mix.Tasks.Elasticsearch.Install do
     unpack(tar, name, "kibana", location)
   end
 
-  defp elasticsearch_tar(name, "7." <> _), do: tar = "#{name}#{os_suffix!()}.tar.gz"
-  defp elasticsearch_tar(name, version), do: tar = "#{name}.tar.gz"
+  defp elasticsearch_tar(name, "7." <> _), do: "#{name}#{os_suffix!()}.tar.gz"
+  defp elasticsearch_tar(name, _version), do: "#{name}.tar.gz"
 
   defp unpack(tar, name, alias, location) do
     System.cmd("tar", ["-zxvf", tar], cd: location)

--- a/priv/bin/wrap
+++ b/priv/bin/wrap
@@ -14,7 +14,7 @@
 #
 # http://erlang.2086793.n4.nabble.com/closing-a-port-doesn-t-kill-the-connected-process-td2119170.html
 
-$1 > /dev/null 2>&1 &
+$@ > /dev/null 2>&1 &
 last_pid=$!
 while read line ; do
   :

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -3,12 +3,14 @@ defmodule Elasticsearch.Test.Cluster do
 
   use Elasticsearch.Cluster
 
-  def init(_config) do
+  def init(config) do
+    url = Map.get(config, :url, "http://localhost:9200")
+
     {:ok,
      %{
        api: Elasticsearch.API.HTTP,
        json_library: Poison,
-       url: "http://localhost:9200",
+       url: url,
        username: "username",
        password: "password",
        indexes: %{

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,5 +1,6 @@
 defmodule Elasticsearch.DataCase do
   @moduledoc false
+
   # This module defines the setup for tests requiring
   # access to the application's data layer.
   #

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,13 +1,16 @@
 ExUnit.start()
 Elasticsearch.Test.Repo.start_link()
 
+port_number = 9200
+url = "http://localhost:#{port_number}"
+
 unless System.get_env("CI") do
   Elasticsearch.Executable.start_link(
     "Elasticsearch",
     "./vendor/elasticsearch/bin/elasticsearch",
-    9200
+    port_number
   )
 end
 
-{:ok, _} = Elasticsearch.Test.Cluster.start_link()
-{:ok, _} = Elasticsearch.wait_for_boot(Elasticsearch.Test.Cluster, 15)
+{:ok, _} = Elasticsearch.Test.Cluster.start_link(%{url: url})
+{:ok, _} = Elasticsearch.wait_for_boot(Elasticsearch.Test.Cluster, 30)


### PR DESCRIPTION
This primarily addresses https://github.com/danielberkompas/elasticsearch-elixir/issues/85 by adjusting the `elasticsearch.install` mix task so that newer versions of elasticsearch can be installed and tested against.

In the process, I also found that the `--port` argument in `Elasticsearch.Executable` was not correct (elasticsearch configuration can be set on the command line using `-E`, see [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/targz.html#targz-configuring)) and that the port argument was not being passed to the `wrap` shell script.

Lastly, I fixed a doctest where the wording for a 'protocol not implemented' error had changed in a more recent version of Elixir. 