### PR TITLE
support bulk delete requests

### DIFF
--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -48,10 +48,23 @@ defmodule Elasticsearch.Index.Bulk do
       {"title":null,"doctype":{"name":"post"},"author":null}
       \"\"\"
 
+      iex> Bulk.encode!(Cluster, %Post{id: "my-id"}, "my-index", "delete")
+      \"\"\"
+      {"delete":{"_index":"my-index","_id":"my-id"}}
+      \"\"\"
+
       iex> Bulk.encode!(Cluster, 123, "my-index")
       ** (Protocol.UndefinedError) protocol Elasticsearch.Document not implemented for 123 of type Integer
   """
-  def encode!(cluster, struct, index, action \\ "create") do
+  def encode!(cluster, struct, index, action \\ "create")
+
+  def encode!(cluster, struct, index, "delete") do
+    config = Cluster.Config.get(cluster)
+    header = header(config, "delete", index, struct)
+    "#{header}\n"
+  end
+
+  def encode!(cluster, struct, index, action) do
     config = Cluster.Config.get(cluster)
     header = header(config, action, index, struct)
 

--- a/test/elasticsearch/indexing/bulk_test.exs
+++ b/test/elasticsearch/indexing/bulk_test.exs
@@ -87,4 +87,11 @@ defmodule Elasticsearch.Index.BulkTest do
                "\"_routing\":\"123\""
     end
   end
+
+  describe ".encode!/4" do
+    test "'delete' omits the struct from the body" do
+      assert "{\"delete\":{\"_routing\":\"123\",\"_index\":\"my-index\",\"_id\":\"my-id\"}}\n" ==
+               Bulk.encode!(Cluster, %Comment{id: "my-id", post_id: "123"}, "my-index", "delete")
+    end
+  end
 end


### PR DESCRIPTION
When the encoded struct 'document' is appended to a bulk request, it causes the bulk request to fail.

As a failing curl: 
```
curl -X PUT "localhost:9200/my-test-index/_bulk?pretty" -v -H 'Content-Type: application/json' -d'
{"delete":{"_id":"8dc97b1d-55f0-4651-810f-ca7c23fa7c59","_index":"my-test-index"}}
{"struct":null,"document":null,"body":null}
'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Malformed action/metadata line [3], expected START_OBJECT or END_OBJECT but found [VALUE_NULL]"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Malformed action/metadata line [3], expected START_OBJECT or END_OBJECT but found [VALUE_NULL]"
  },
  "status" : 400
}
```

As a success curl: 
```
curl -X PUT "localhost:9200/my-test-index/_bulk?pretty" -v -H 'Content-Type: application/json' -d'
{"delete":{"_id":"8dc97b1d-55f0-4651-810f-ca7c23fa7c59","_index":"my-test-index"}}
'
{
  "took" : 0,
  "errors" : true,
  "items" : [
    {
      "delete" : {
        "_index" : "my-test-index",
        "_type" : "_doc",
        "_id" : "8dc97b1d-55f0-4651-810f-ca7c23fa7c59",
        "status" : 404,
        "error" : {
          "type" : "index_not_found_exception",
          "reason" : "no such index [my-test-index]",
          "resource.type" : "index_expression",
          "resource.id" : "my-test-index",
          "index_uuid" : "_na_",
          "index" : "my-test-index"
        }
      }
    }
  ]
}
```